### PR TITLE
Move GBP currency symbols

### DIFF
--- a/MacWalletApp/MacWallet/tickers.plist
+++ b/MacWalletApp/MacWallet/tickers.plist
@@ -11,7 +11,7 @@
 		<key>url</key>
 		<string>https://bitpay.com/api/rates</string>
 		<key>format</key>
-		<string>%@ £</string>
+		<string>£%@</string>
 	</dict>
 	<key>BITPAY EUR</key>
 	<dict>
@@ -66,7 +66,7 @@
 		<key>url</key>
 		<string>https://api.bitcoinaverage.com/ticker/GBP</string>
 		<key>format</key>
-		<string>%@ £</string>
+		<string>£%@</string>
 	</dict>
 	<key>MTGOX USD</key>
 	<dict>


### PR DESCRIPTION
Moving £ symbols to immediately before monetary unit as is customary in UK as we don't follow normal European conventions
